### PR TITLE
Update brls.json

### DIFF
--- a/resources/i18n/zh-TW/brls.json
+++ b/resources/i18n/zh-TW/brls.json
@@ -8,6 +8,6 @@
         "button": "確定"
     },
     "thumbnail_sidebar": {
-        "save": "保存"
+        "save": "儲存"
     }
 }


### PR DESCRIPTION
Fixed v2.19.0 Updated Chinese localisation (from https://github.com/Physton).
His/Her Traditional Chinese translation is suited for China , not for Taiwan.