### PR TITLE
Skip nx-ovlloader when disabling sysmodules startup flags

### DIFF
--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -302,7 +302,8 @@ namespace util {
     void removeSysmodulesFlags(const std::string& directory)
     {
         for (const auto& e : std::filesystem::recursive_directory_iterator(directory)) {
-            if (e.path().string().find("boot2.flag") != std::string::npos) {
+            if (e.path().string().find("boot2.flag") != std::string::npos &&
+                e.path().string().find("420000000007E51A") == std::string::npos) {
                 std::filesystem::remove(e.path());
             }
         }


### PR DESCRIPTION
This might be more convenient.
From the Tesla Menu you can directly re-activate the other sysmodules (using overlays like for example ovl-sysmodules) without needing to connect to a PC.
The only downside of this would be the possibility of nx-ovlloader causing the system to fail to boot on the latest update, but, I believe, it's a rather negligible risk. At least, it never happened to me.