### PR TITLE
Install switch-glad dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ sudo (dkp-)pacman -Sy
 ```bash
 $ sudo (dkp-)pacman -S  switch-glfw \
                         switch-curl \
+                        switch-glad \
                         switch-glm \
                         switch-mbedtls \
                         switch-zlib


### PR DESCRIPTION
To address the <glad/glad.h> not found error when compiling with Apple M1.